### PR TITLE
Make service name overrideable to enable distinguishing different pla…

### DIFF
--- a/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
+++ b/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
@@ -29,8 +29,10 @@ import com.github.levkhomich.akka.tracing.http.TracingHeaders
 
 trait TracingSettings extends GlobalSettings with PlayControllerTracing {
 
+  lazy val serviceName = play.libs.Akka.system.name
+  
   protected def sample(request: RequestHeader): Unit = {
-    trace.sample(request, play.libs.Akka.system.name)
+    trace.sample(request, serviceName)
   }
 
   protected def addHttpAnnotations(request: RequestHeader): Unit = {


### PR DESCRIPTION
…y applications in traces.

In an environment with multiple Play applications it is highly desirable to be able to specify the service name, making it a lazy val enables overriding the value in the applications Global object with a suitable name