### PR TITLE
Ensure sampling decisions are honoured across services (re-submitted)

### DIFF
--- a/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
+++ b/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
@@ -36,13 +36,13 @@ trait TracingSettings extends GlobalSettings with PlayControllerTracing {
   lazy val excludedHeaders = Set.empty[String]
 
   protected def sample(request: RequestHeader): Unit = {
-    val upstreamSampling = request.headers.get(TracingHeaders.Sampled).map(_.toBoolean)
+    val upstreamSampling = request.headers.get(TracingHeaders.Sampled).map(_.toLowerCase)
     upstreamSampling match {
-      case Some(true) =>
+      case Some("true") | Some("1") =>
         trace.sample(request, serviceName, true)
       case None =>
         trace.sample(request, serviceName)
-      case Some(false) =>
+      case Some(x) =>
       // don't sample
     }
   }

--- a/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
+++ b/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
@@ -36,7 +36,15 @@ trait TracingSettings extends GlobalSettings with PlayControllerTracing {
   lazy val excludedHeaders = Set.empty[String]
 
   protected def sample(request: RequestHeader): Unit = {
-    trace.sample(request, serviceName)
+    val upstreamSampling = request.headers.get(TracingHeaders.Sampled).map(_.toBoolean)
+    upstreamSampling match {
+      case Some(true) =>
+        trace.sample(request, serviceName, true)
+      case None =>
+        trace.sample(request, serviceName)
+      case Some(false) =>
+      // don't sample
+    }
   }
 
   protected def addHttpAnnotations(request: RequestHeader): Unit = {

--- a/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
+++ b/play/src/main/scala/com/github/levkhomich/akka/tracing/play/TracingSettings.scala
@@ -38,12 +38,12 @@ trait TracingSettings extends GlobalSettings with PlayControllerTracing {
   protected def sample(request: RequestHeader): Unit = {
     val upstreamSampling = request.headers.get(TracingHeaders.Sampled).map(_.toLowerCase)
     upstreamSampling match {
-      case Some("true") | Some("1") =>
+      case Some("0") | Some("false") =>
+      // do not sample
+      case Some("1") | Some("true") =>
         trace.sample(request, serviceName, true)
-      case None =>
+      case Some(_) | None =>
         trace.sample(request, serviceName)
-      case Some(x) =>
-      // don't sample
     }
   }
 

--- a/play/src/test/scala/com/github/levkhomich/akka/tracing/play/PlayTracingSpec.scala
+++ b/play/src/test/scala/com/github/levkhomich/akka/tracing/play/PlayTracingSpec.scala
@@ -171,12 +171,22 @@ class PlayTracingSpec extends PlaySpecification with TracingTestCommons with Moc
       expectSpans(0)
     }
 
-    "ensure upstream 'do sample' decision is honoured" in new WithApplication(disabledLocalSamplingApplication) {
+    "ensure upstream 'do sample' decision is honoured" in new WithApplication(fakeApplication) {
       val spanId = Random.nextLong
       val result = route(FakeRequest("GET", TestPath + "?key=value",
         FakeHeaders(Seq(
           TracingHeaders.TraceId -> Seq(SpanMetadata.idToString(spanId)),
           TracingHeaders.Sampled -> Seq("true")
+        )), AnyContentAsEmpty)).map(Await.result(_, defaultAwaitTimeout.duration))
+      expectSpans(1)
+    }
+
+    "ensure upstream 'do sample' decision is honoured (binary value)" in new WithApplication(fakeApplication) {
+      val spanId = Random.nextLong
+      val result = route(FakeRequest("GET", TestPath + "?key=value",
+        FakeHeaders(Seq(
+          TracingHeaders.TraceId -> Seq(SpanMetadata.idToString(spanId)),
+          TracingHeaders.Sampled -> Seq("1")
         )), AnyContentAsEmpty)).map(Await.result(_, defaultAwaitTimeout.duration))
       expectSpans(1)
     }

--- a/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
+++ b/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
@@ -40,7 +40,7 @@ trait TracedSprayPipeline {
   private[this] def untracedRequest(traceId: Long): SendReceive = {
     addHeaders(List(
       HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(traceId)),
-      HttpHeaders.RawHeader(TracingHeaders.Sampled, "false")
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "0")
     )) ~>
       sendAndReceive
   }
@@ -50,7 +50,7 @@ trait TracedSprayPipeline {
       HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(metadata.traceId)),
       HttpHeaders.RawHeader(TracingHeaders.SpanId, SpanMetadata.idToString(metadata.spanId)),
       HttpHeaders.RawHeader(TracingHeaders.ParentSpanId, SpanMetadata.idToString(metadata.parentId.get)),
-      HttpHeaders.RawHeader(TracingHeaders.Sampled, "true")
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "1")
     )) ~>
       startTrace(clientRequest) ~>
       sendAndReceive ~>

--- a/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
+++ b/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
@@ -34,16 +34,27 @@ trait TracedSprayPipeline {
 
   def tracedPipeline[T](parent: BaseTracingSupport): SendReceive = {
     val clientRequest = new TracingSupport {}
-    trace.createChild(clientRequest, parent).map(metadata =>
-      addHeaders(List(
-        HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(metadata.traceId)),
-        HttpHeaders.RawHeader(TracingHeaders.SpanId, SpanMetadata.idToString(metadata.spanId)),
-        HttpHeaders.RawHeader(TracingHeaders.ParentSpanId, SpanMetadata.idToString(metadata.parentId.get)),
-        HttpHeaders.RawHeader(TracingHeaders.Sampled, "true")
-      )) ~>
-        startTrace(clientRequest) ~>
-        sendAndReceive ~>
-        completeTrace(clientRequest)).getOrElse(sendAndReceive)
+    trace.createChild(clientRequest, parent).map(tracedRequest(clientRequest, _)).getOrElse(untracedRequest(parent.tracingId))
+  }
+
+  private[this] def untracedRequest(traceId: Long): SendReceive = {
+    addHeaders(List(
+      HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(traceId)),
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "false")
+    )) ~>
+      sendAndReceive
+  }
+
+  private[this] def tracedRequest(clientRequest: BaseTracingSupport, metadata: SpanMetadata): SendReceive = {
+    addHeaders(List(
+      HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(metadata.traceId)),
+      HttpHeaders.RawHeader(TracingHeaders.SpanId, SpanMetadata.idToString(metadata.spanId)),
+      HttpHeaders.RawHeader(TracingHeaders.ParentSpanId, SpanMetadata.idToString(metadata.parentId.get)),
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "true")
+    )) ~>
+      startTrace(clientRequest) ~>
+      sendAndReceive ~>
+      completeTrace(clientRequest)
   }
 
   def startTrace(ts: BaseTracingSupport)(request: HttpRequest): HttpRequest = {

--- a/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
+++ b/spray-client/src/main/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipeline.scala
@@ -40,7 +40,7 @@ trait TracedSprayPipeline {
   private[this] def untracedRequest(traceId: Long): SendReceive = {
     addHeaders(List(
       HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(traceId)),
-      HttpHeaders.RawHeader(TracingHeaders.Sampled, "0")
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "false")
     )) ~>
       sendAndReceive
   }
@@ -50,7 +50,7 @@ trait TracedSprayPipeline {
       HttpHeaders.RawHeader(TracingHeaders.TraceId, SpanMetadata.idToString(metadata.traceId)),
       HttpHeaders.RawHeader(TracingHeaders.SpanId, SpanMetadata.idToString(metadata.spanId)),
       HttpHeaders.RawHeader(TracingHeaders.ParentSpanId, SpanMetadata.idToString(metadata.parentId.get)),
-      HttpHeaders.RawHeader(TracingHeaders.Sampled, "1")
+      HttpHeaders.RawHeader(TracingHeaders.Sampled, "true")
     )) ~>
       startTrace(clientRequest) ~>
       sendAndReceive ~>

--- a/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
+++ b/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
@@ -53,7 +53,7 @@ class TracedSprayPipelineSpec extends Specification with FutureMatchers with Tra
         override def sendAndReceive = {
           case req: HttpRequest =>
             result.trySuccess(
-              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("false")) and
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("0")) and
                 (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
             )
             Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))
@@ -72,7 +72,7 @@ class TracedSprayPipelineSpec extends Specification with FutureMatchers with Tra
         override def sendAndReceive = {
           case req: HttpRequest =>
             result.trySuccess(
-              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("true")) and
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("1")) and
                 (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
             )
             Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))

--- a/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
+++ b/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
@@ -53,7 +53,7 @@ class TracedSprayPipelineSpec extends Specification with FutureMatchers with Tra
         override def sendAndReceive = {
           case req: HttpRequest =>
             result.trySuccess(
-              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("0")) and
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("false")) and
                 (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
             )
             Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))
@@ -72,7 +72,7 @@ class TracedSprayPipelineSpec extends Specification with FutureMatchers with Tra
         override def sendAndReceive = {
           case req: HttpRequest =>
             result.trySuccess(
-              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("1")) and
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("true")) and
                 (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
             )
             Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))

--- a/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
+++ b/spray-client/src/test/scala/com/github/levkhomich/akka/tracing/http/TracedSprayPipelineSpec.scala
@@ -1,9 +1,10 @@
 package com.github.levkhomich.akka.tracing.http
 
-import scala.concurrent.Future
+import scala.concurrent.{ Promise, Future }
 
 import org.specs2.matcher.FutureMatchers
 import org.specs2.mutable.Specification
+import org.specs2.matcher.MatchResult
 import spray.client.pipelining._
 import spray.http._
 
@@ -42,6 +43,43 @@ class TracedSprayPipelineSpec extends Specification with FutureMatchers with Tra
       childSpan.trace_id mustEqual parentSpan.trace_id
       childSpan.parent_id mustEqual parentSpan.id
       childSpan.id mustNotEqual parentSpan.id
+    }
+
+    "indicate to downstream service trace is not sampled if we are not sampling" in {
+      val result = Promise[MatchResult[_]]()
+      val parent = nextRandomMessage
+      val testPipeline = new TracedSprayPipeline {
+        val system = self.system
+        override def sendAndReceive = {
+          case req: HttpRequest =>
+            result.trySuccess(
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("false")) and
+                (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
+            )
+            Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))
+        }
+      }
+      testPipeline.tracedPipeline[String](parent)(Get("http://test.com"))
+      result.future.await
+    }
+
+    "indicate to downstream service that we are sampled along with the trace id if we are sampling" in {
+      val result = Promise[MatchResult[_]]()
+      val parent = nextRandomMessage
+      trace.sample(parent, "test trace", force = true)
+      val testPipeline = new TracedSprayPipeline {
+        val system = self.system
+        override def sendAndReceive = {
+          case req: HttpRequest =>
+            result.trySuccess(
+              (req.headers.find(_.name == TracingHeaders.Sampled).map(_.value) must beSome("true")) and
+                (req.headers.find(_.name == TracingHeaders.TraceId).map(_.value) must not beNull)
+            )
+            Future.successful(HttpResponse(StatusCodes.OK, bodyEntity))
+        }
+      }
+      testPipeline.tracedPipeline[String](parent)(Get("http://test.com"))
+      result.future.await
     }
   }
 


### PR DESCRIPTION
Replacement clean pull request (replacing pull/69), includes using Boolean values for downstream X-B3-Sampled values as discussed 